### PR TITLE
Improved 1.14.4 compatibility

### DIFF
--- a/API/src/main/java/com/lishid/orebfuscator/nms/INmsManager.java
+++ b/API/src/main/java/com/lishid/orebfuscator/nms/INmsManager.java
@@ -55,4 +55,8 @@ public interface INmsManager {
 	Set<Integer> getMaterialIds(Material material);
 
 	boolean sendBlockChange(Player player, Location blockLocation);
+
+    default boolean hasLightArray() { return true; }
+    
+    default boolean hasBlockCount() { return false; };
 }

--- a/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkMapBuffer.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkMapBuffer.java
@@ -44,6 +44,7 @@ public class ChunkMapBuffer {
 	public ChunkLayer curLayer;
 	public ChunkLayer nextLayer;
 
+    public int blockCount;
 	public int bitsPerBlock;
 	public int paletteLength;
 	public int dataArrayLength;

--- a/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkMapManager.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkMapManager.java
@@ -67,7 +67,7 @@ public class ChunkMapManager implements AutoCloseable {
 		manager.minZ = chunkData.chunkZ << 4;
 		manager.maxZ = manager.minZ + 15;
 
-		manager.buffer.lightArrayLength = 2048;
+		manager.buffer.lightArrayLength = NmsInstance.get().hasLightArray() ? 2048 : 0;
 
 		if (chunkData.isOverworld) {
 			manager.buffer.lightArrayLength <<= 1;
@@ -146,6 +146,10 @@ public class ChunkMapManager implements AutoCloseable {
 
 		this.buffer.writer.setBitsPerBlock(this.buffer.outputBitsPerBlock);
 
+		// Block count
+		if(NmsInstance.get().hasBlockCount())
+		    this.buffer.writer.writeShort((short) this.buffer.blockCount);
+		
 		// Bits Per Block
 		this.buffer.writer.writeByte((byte) this.buffer.outputBitsPerBlock);
 
@@ -355,6 +359,8 @@ public class ChunkMapManager implements AutoCloseable {
 	}
 
 	private void readSectionHeader() throws IOException {
+	    if(NmsInstance.get().hasBlockCount())
+	            this.buffer.blockCount = this.reader.readShort();
 		this.buffer.bitsPerBlock = this.reader.readByte();
 		this.buffer.paletteLength = this.reader.readVarInt();
 

--- a/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkReader.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkReader.java
@@ -99,4 +99,11 @@ public class ChunkReader {
 
 		return this.data[this.byteIndex++] & 0xff;
 	}
+
+    public int readShort() throws IOException {
+        int b1 = readByte();
+        int b2 = readByte();
+        
+        return (b1 << 8) | b2;
+    }
 }

--- a/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkWriter.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/chunkmap/ChunkWriter.java
@@ -105,4 +105,13 @@ public class ChunkWriter {
 
 		this.data[this.byteIndex++] = (byte) value;
 	}
+
+    public void writeShort(int blockCount) throws IOException {
+        if (this.byteIndex + 1 >= this.data.length) {
+            throw new IOException("No space to write.");
+        }
+
+        this.data[this.byteIndex++] = (byte) (blockCount >> 8);
+        this.data[this.byteIndex++] = (byte) (blockCount >> 0);
+    }
 }

--- a/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/BlockUpdate.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/BlockUpdate.java
@@ -68,14 +68,16 @@ public class BlockUpdate {
 
 				getAdjacentBlocks(updateBlocks, world, worldConfig, blockInfo, updateRadius);
 
-				if ((blockInfo.getX() & 0xf) == 0) {
-					invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) - 1, blockInfo.getZ() >> 4));
-				} else if (((blockInfo.getX() + 1) & 0xf) == 0) {
-					invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) + 1, blockInfo.getZ() >> 4));
-				} else if (((blockInfo.getZ()) & 0xf) == 0) {
-					invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) - 1));
-				} else if (((blockInfo.getZ() + 1) & 0xf) == 0) {
-					invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) + 1));
+				if(blockInfo != null) {
+    				if ((blockInfo.getX() & 0xf) == 0) {
+    					invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) - 1, blockInfo.getZ() >> 4));
+    				} else if (((blockInfo.getX() + 1) & 0xf) == 0) {
+    					invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) + 1, blockInfo.getZ() >> 4));
+    				} else if (((blockInfo.getZ()) & 0xf) == 0) {
+    					invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) - 1));
+    				} else if (((blockInfo.getZ() + 1) & 0xf) == 0) {
+    					invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) + 1));
+    				}
 				}
 			}
 		}
@@ -102,14 +104,16 @@ public class BlockUpdate {
 
 			getAdjacentBlocks(updateBlocks, world, worldConfig, blockInfo, updateRadius);
 
-			if ((blockInfo.getX() & 0xf) == 0) {
-				invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) - 1, blockInfo.getZ() >> 4));
-			} else if (((blockInfo.getX() + 1) & 0xf) == 0) {
-				invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) + 1, blockInfo.getZ() >> 4));
-			} else if (((blockInfo.getZ()) & 0xf) == 0) {
-				invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) - 1));
-			} else if (((blockInfo.getZ() + 1) & 0xf) == 0) {
-				invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) + 1));
+			if(blockInfo != null) {
+    			if ((blockInfo.getX() & 0xf) == 0) {
+    				invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) - 1, blockInfo.getZ() >> 4));
+    			} else if (((blockInfo.getX() + 1) & 0xf) == 0) {
+    				invalidChunks.add(new ChunkCoord((blockInfo.getX() >> 4) + 1, blockInfo.getZ() >> 4));
+    			} else if (((blockInfo.getZ()) & 0xf) == 0) {
+    				invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) - 1));
+    			} else if (((blockInfo.getZ() + 1) & 0xf) == 0) {
+    				invalidChunks.add(new ChunkCoord(blockInfo.getX() >> 4, (blockInfo.getZ() >> 4) + 1));
+    			}
 			}
 		}
 

--- a/v1_14_R1/src/main/java/com/lishid/orebfuscator/nms/v1_14_R1/NmsManager.java
+++ b/v1_14_R1/src/main/java/com/lishid/orebfuscator/nms/v1_14_R1/NmsManager.java
@@ -561,23 +561,8 @@ public class NmsManager implements INmsManager {
 		int chunkZ = z >> 4;
 
 		WorldServer worldServer = ((CraftWorld) world).getHandle();
-		// like in ChunkCache, NMS change without R increment.
-		ChunkProviderServer chunkProviderServer = null;
-		try {
-			Method getChunkProviderServer = worldServer.getClass().getDeclaredMethod("getChunkProviderServer");
-			chunkProviderServer = (ChunkProviderServer) getChunkProviderServer.invoke(worldServer);
-		} catch (NoSuchMethodException nmfe) {
-			try {
-				Method getChunkProvider = worldServer.getClass().getDeclaredMethod("getChunkProvider");
-				chunkProviderServer = (ChunkProviderServer) getChunkProvider.invoke(worldServer);
-			} catch (NoSuchMethodException nsme) {
-				return null; // oops
-			} catch (Exception e) {
-				return null;
-			}
-		} catch (Exception e) {
-			return null;
-		}
+		ChunkProviderServer chunkProviderServer = worldServer.getChunkProvider();
+
 		if (!loadChunk && !chunkProviderServer.isLoaded(chunkX, chunkZ))
 			return null;
 
@@ -608,4 +593,15 @@ public class NmsManager implements INmsManager {
 
 		return result;
 	}
+	
+	@Override
+	public boolean hasLightArray() {
+	    return false;
+	}
+	
+	@Override
+	public boolean hasBlockCount() {
+	    return true;
+	}
+	
 }


### PR DESCRIPTION
- removed reflection from NmsManager, since it was only for 1.13.2
- added null check to BlockUpdate, since it's nullable
- use blockCount field when using 1.14.4
- don't use lightingArray when using 1.14.4

This should be backwards compatible (tested with 1.13.2).